### PR TITLE
Update Dockerfile.ddev-taskfile (curl installation removed)

### DIFF
--- a/web-build/Dockerfile.ddev-taskfile
+++ b/web-build/Dockerfile.ddev-taskfile
@@ -1,4 +1,3 @@
 #ddev-generated
 # Execute taskfile installer
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests curl
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin


### PR DESCRIPTION
Uninstalling curl, which is already installed in the ddev image, and reinstalling it causes an error
![image](https://github.com/gebruederheitz/ddev-taskfile/assets/90793591/1413c534-7d0f-4729-a312-078e213dbc0c)
