### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 
 This repository is providing the taskfile.dev executable `task` for ddev projects.
 
-Install it with `ddev get gebruederheitz/ddev-taskfile`.
+To install it, for DDEV v1.23.5 or above run
 
+```sh
+ddev add-on get gebruederheitz/ddev-taskfile
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get gebruederheitz/ddev-taskfile
+```
 
 **Contributed and maintained by [@CONTRIBUTOR](https://github.com/CONTRIBUTOR) based on the original [ddev-contrib recipe](https://github.com/drud/ddev-contrib/tree/master/docker-compose-services/RECIPE) by [@CONTRIBUTOR](https://github.com/CONTRIBUTOR)**
 
 **Originally Contributed by [somebody](https://github.com/somebody) in https://github.com/drud/ddev-contrib/...)
-
-


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.